### PR TITLE
Reduced size of drawable to temporarily fix #5

### DIFF
--- a/googlemapsanimations/src/main/res/drawable/background.xml
+++ b/googlemapsanimations/src/main/res/drawable/background.xml
@@ -2,8 +2,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
     <size
-        android:width="1500dp"
-        android:height="1500dp"></size>
+        android:width="400dp"
+        android:height="400dp"></size>
     <stroke
         android:width="10dp"
         android:color="#000000"></stroke>


### PR DESCRIPTION
Not the best solution though. Drawable size should be calculated through code based on multiple factors such as device screen size and ```withDistance``` value. But for now and until you have some time this should allow users to use the library (but not without a HUGE abuse of memory due to it's implementation).